### PR TITLE
Support alternative markdown queries (such as allMdx)

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -10,7 +10,7 @@ export function createPages({ graphql, actions }, pluginOptions) {
       graphql(
         `
           {
-            ${markdownQuery}(
+            q: ${markdownQuery}(
               filter: { frontmatter: { redirect_from: { ne: null } } }
             ) {
               edges {
@@ -32,7 +32,7 @@ export function createPages({ graphql, actions }, pluginOptions) {
           reject(result.errors)
         }
 
-        const allPosts = result.data.allMarkdownRemark.edges
+        const allPosts = result.data.q.edges
 
         const redirects = []
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,14 +1,16 @@
 import chalk from 'chalk'
 
-export function createPages({ graphql, actions }) {
+export function createPages({ graphql, actions }, pluginOptions) {
   const { createRedirect } = actions
+
+  const markdownQuery = pluginOptions.query || 'allMarkdownRemark'
 
   return new Promise((resolve, reject) => {
     resolve(
       graphql(
         `
           {
-            allMarkdownRemark(
+            ${markdownQuery}(
               filter: { frontmatter: { redirect_from: { ne: null } } }
             ) {
               edges {


### PR DESCRIPTION
Ive been using this plugin successfully with the standard remark markdown Gatsby plugin, but have recently moved to use [Mdx Js](https://mdxjs.com) for more advanced markdown, which means that my GraphQL queries have changed from `allMarkdownRemark` to `allMdx`, which currently isn't supported here.

This PR adds a plugin option, `query`, which allows the user to change the default query used for getting redirect front matter parameters.