### PR TITLE
specify node 8 instead of 10 as engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gatsby-plugin-meta-redirect": ">=1.1.0"
   },
   "engines": {
-    "node": "^10.0.0"
+    "node": "^8.0.0"
   },
   "repository": "github:kremalicious/gatsby-redirect-from",
   "bugs": {


### PR DESCRIPTION
- it works in node 8
- unnecessarily causes build failures in CI when installed via yarn