### PR TITLE
Update gatsby-node.js to use slug from frontmatter

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -62,7 +62,7 @@ export async function createPages({ graphql, actions }, pluginOptions) {
     allPosts.forEach(({ node }) => {
       let _slug
       const { redirect_from, slug } = node.frontmatter
-      if (!slug) _slug = node.fields?.slug
+      _slug = slug || node.fields?.slug;
       if (!_slug) {
         console.log(
           '%c %s %c %s',


### PR DESCRIPTION
update line 65 : the previous code did not use slug to set _slug variable. So the frontmatter slug value was not used even if it was set